### PR TITLE
Container + BorderLayout

### DIFF
--- a/src/main/java/java/awt/BorderLayout.java
+++ b/src/main/java/java/awt/BorderLayout.java
@@ -372,6 +372,11 @@ public class BorderLayout implements LayoutManager2, java.io.Serializable {
 			name = "Center";
 		}
 
+		Component old = getLayoutComponent(name);
+		if (old != null && old.parent != null) {
+			old.parent.remove(old);
+			old.parent = null;
+		}
 		/*
 		 * Assign the component to one of the known regions of the layout.
 		 */
@@ -417,6 +422,8 @@ public class BorderLayout implements LayoutManager2, java.io.Serializable {
 	 * @see java.awt.Container#removeAll()
 	 */
 	public void removeLayoutComponent(Component comp) {
+		comp.getHTMLElement().parentNode.removeChild(comp.getHTMLElement());
+
 		if (comp == center) {
 			center = null;
 		} else if (comp == north) {
@@ -543,18 +550,26 @@ public class BorderLayout implements LayoutManager2, java.io.Serializable {
 			table.style.left = "0px";
 			table.style.right = "0px";
 			table.style.zIndex = "0";
+			table.style.border = "0px";
+			table.cellSpacing = "0px";
+			table.cellPadding = "0px";
 
 			for (int j = 0; j < 3; j++) {
 				HTMLTableRowElement row = document.createElement(StringTypes.tr);
 				table.appendChild(row);
-				if(j==0 || j==2) {
-					row.style.height = "0%";
+				if(j != 1) {
+					row.style.height = "0px";
+				} else {
+					row.style.height = "100%";
 				}
 				for (int i = 0; i < 3; i++) {
 					HTMLTableDataCellElement col = document.createElement(StringTypes.td);
+					col.style.padding = "0px";
 					row.appendChild(col);
-					if(i==0 || i==2) {
-						col.style.width = "0%";
+					if(i != 1 || j != 1) {
+						col.style.width = "0px";
+					} else {
+						col.style.width = "100%";
 					}
 				}
 			}

--- a/src/main/java/java/awt/Container.java
+++ b/src/main/java/java/awt/Container.java
@@ -105,6 +105,10 @@ public abstract class Container extends Component {
 				layoutMgr.addLayoutComponent((String) constraints, this);
 			}
 		}
+
+		if (component.getHTMLElement().parentNode == null) {
+			getHTMLElement().appendChild(component.getHTMLElement());
+		}
 	}
 
 	@Override
@@ -141,6 +145,12 @@ public abstract class Container extends Component {
 	public void remove(Component c) {
 		if (layoutMgr != null) {
 			layoutMgr.removeLayoutComponent(c);
+		}
+
+		c.parent = null;
+
+		if (c.getHTMLElement().parentNode == getHTMLElement()) {
+			getHTMLElement().removeChild(c.getHTMLElement());
 		}
 
 		int i = array(components).indexOf(c);

--- a/src/main/java/java/awt/Container.java
+++ b/src/main/java/java/awt/Container.java
@@ -75,7 +75,7 @@ public abstract class Container extends Component {
 	}
 
 	public Component add(String name, Component component) {
-		addImpl(component, null, -1);
+		addImpl(component, name, -1);
 		return component;
 	}
 
@@ -88,13 +88,21 @@ public abstract class Container extends Component {
 	}
 
 	protected void addImpl(Component component, Object constraints, int index) {
+		if (component.parent != null) {
+			component.parent.remove(component);
+		}
+
 		array(components).push(component);
+
 		component.initHTML();
+
+		component.parent = this;
+
 		if (layoutMgr != null) {
-			if (constraints != null && layoutMgr instanceof LayoutManager2) {
+			if (layoutMgr instanceof LayoutManager2) {
 				((LayoutManager2) layoutMgr).addLayoutComponent(component, constraints);
-			} else {
-				layoutMgr.onComponentAdded(this, component, -1);
+			} else if (constraints instanceof String){
+				layoutMgr.addLayoutComponent((String) constraints, this);
 			}
 		}
 	}
@@ -112,7 +120,7 @@ public abstract class Container extends Component {
 	}
 
 	public void remove(int index) {
-		components = array(components).slice(index, 1);
+		remove(array(components).$get(index));
 	}
 
 	public Component getComponent(int n) {
@@ -124,12 +132,19 @@ public abstract class Container extends Component {
 	}
 
 	public void removeAll() {
+		if (layoutMgr != null) {
+			array(components).forEach(layoutMgr::removeLayoutComponent);
+		}
 		components = new Component[0];
 	}
 
 	public void remove(Component c) {
-		int i = (int) array(components).indexOf(c);
-		remove(i);
+		if (layoutMgr != null) {
+			layoutMgr.removeLayoutComponent(c);
+		}
+
+		int i = array(components).indexOf(c);
+		components = array(components).slice(i, 1);
 	}
 
 	public Insets getInsets() {


### PR DESCRIPTION
in Java, Borderlayout handles only 1 element per constraint (NORTH /SOUTH/EAST/WEST/CENTER)
this means we need to remove sometimes the elements.

"0%" is not working sometimes, this is why I rewrite to "0px".
In Java Gui there are no borders and no paddings, so i add some styling

I copied from Oracle code the Container's layout handling.
This means on add, need to set parent, and call layoutmanager add (which sets HTMLElement parents too)
And on delete the same as expected