### PR TITLE
format html elements

### DIFF
--- a/src/main/java/java/awt/Window.java
+++ b/src/main/java/java/awt/Window.java
@@ -51,13 +51,16 @@ public class Window extends Container {
 	@Override
 	public void createHTML() {
 		htmlElement = document.createElement(StringTypes.div);
-		htmlElement.style.display = "none";
+		getElement().style.display = "none";
 		window.addEventListener(StringTypes.load, (e) -> {
-			System.out.println("window onload hook");
 			if (document.body == null) {
 				throw new Error("no body found");
 			}
-			document.body.appendChild(htmlElement);
+			document.body.style.margin = "0px";
+			document.body.parentElement.style.height = "100%";
+			document.body.style.height = "100%";
+
+			document.body.appendChild(getElement());
 			doPaintInternal();
 			return null;
 		});

--- a/src/main/java/javax/swing/JTextField.java
+++ b/src/main/java/javax/swing/JTextField.java
@@ -45,7 +45,7 @@ public class JTextField extends JTextComponent implements SwingConstants {
 
 	@Override
 	public HTMLInputElement getHTMLElement() {
-		return any(htmlElement);
+		return any(super.getHTMLElement());
 	}
 
 	@Override
@@ -54,7 +54,10 @@ public class JTextField extends JTextComponent implements SwingConstants {
 			return;
 		}
 		htmlElement = document.createElement(StringTypes.input);
-		htmlElement.setAttribute("type", "text");
+		getHTMLElement().setAttribute("type", "text");
+		getHTMLElement().style.background = "transparent";
+		getHTMLElement().style.border = "none";
+		getHTMLElement().style.padding = "0px";
 	}
 
 	@Override


### PR DESCRIPTION
document body style is (in Java) starts 0 0 px (top left), this is why I set margin to 0.
The Java gui fills all the space, and this is why set 100% height each main element.

I Tried with JTextField, and it is a no-decoration text field, and I set the format tags. 